### PR TITLE
Remove validation of student gender

### DIFF
--- a/lib/clever-ruby/models/student.rb
+++ b/lib/clever-ruby/models/student.rb
@@ -265,8 +265,6 @@ module Clever
     def valid?
       ell_status_validator = EnumAttributeValidator.new('String', ["Y", "N", ""])
       return false unless ell_status_validator.valid?(@ell_status)
-      gender_validator = EnumAttributeValidator.new('String', ["M", "F", ""])
-      return false unless gender_validator.valid?(@gender)
       hispanic_ethnicity_validator = EnumAttributeValidator.new('String', ["Y", "N", ""])
       return false unless hispanic_ethnicity_validator.valid?(@hispanic_ethnicity)
       home_language_validator = EnumAttributeValidator.new('String', ["English", "Albanian", "Amharic", "Arabic", "Bengali", "Bosnian", "Burmese", "Cantonese", "Chinese", "Dutch", "Farsi", "French", "German", "Hebrew", "Hindi", "Hmong", "Ilocano", "Japanese", "Javanese", "Karen", "Khmer", "Korean", "Laotian", "Latvian", "Malay", "Mandarin", "Nepali", "Oromo", "Polish", "Portuguese", "Punjabi", "Romanian", "Russian", "Samoan", "Serbian", "Somali", "Spanish", "Swahili", "Tagalog", "Tamil", "Telugu", "Thai", "Tigrinya", "Turkish", "Ukrainian", "Urdu", "Vietnamese"])
@@ -284,16 +282,6 @@ module Clever
         fail ArgumentError, "invalid value for 'ell_status', must be one of #{validator.allowable_values}."
       end
       @ell_status = ell_status
-    end
-
-    # Custom attribute writer method checking allowed values (enum).
-    # @param [Object] gender Object to be assigned
-    def gender=(gender)
-      validator = EnumAttributeValidator.new('String', ["M", "F", ""])
-      unless validator.valid?(gender)
-        fail ArgumentError, "invalid value for 'gender', must be one of #{validator.allowable_values}."
-      end
-      @gender = gender
     end
 
     # Custom attribute writer method checking allowed values (enum).

--- a/lib/clever-ruby/version.rb
+++ b/lib/clever-ruby/version.rb
@@ -11,5 +11,5 @@ Swagger Codegen version: 2.3.0-SNAPSHOT
 =end
 
 module Clever
-  VERSION = "2.1.1"
+  VERSION = "2.1.2"
 end


### PR DESCRIPTION
# Card
https://trello.com/c/sv0QmFRD

# Description
The issue occurs because we've got a student with gender set to `X` while syncing District `#9659`. Although Clever doc says that possible values for `gender` are `['M', 'F']`, that apparently means that other values might come as well. Here is a student:

```
[{"data"=>
   {"enrollments"=>[{"end_date"=>"2021-06-18T00:00:00.000Z", "school"=>"5f60fcf471f43507f3f3097a", "start_date"=>"2020-09-15T00:00:00.000Z"}],
    "gender"=>"X",
    "grade"=>"9",
    "last_modified"=>"2021-05-05T17:04:04.985Z",
    "name"=>{"middle"=>"Sierra Glen", "first"=>"Kai", "last"=>"Court"},
    "sis_id"=>"2103",
    "district"=>"5f60f78925d8de000189bf8c",
    "email"=>"2024aspenb@lunenburgschools.net",
    "created"=>"2020-09-15T17:42:23.537Z",
    "school"=>"5f60fcf471f43507f3f3097a",
    "graduation_year"=>"",
    "schools"=>["5f60fcf471f43507f3f3097a"],
    "id"=>"5f60fcf471f43507f3f309e3"},
  "uri"=>"/v2.1/students/5f60fcf471f43507f3f309e3"}]
```

I think that'd be OK just to remove the validation for `gender` since we don't handle it anyhow.

# References
- https://dev.clever.com/docs/data-model#schema